### PR TITLE
merging request headers

### DIFF
--- a/pygerrit2/rest/__init__.py
+++ b/pygerrit2/rest/__init__.py
@@ -53,6 +53,27 @@ def _decode_response(response):
         raise
 
 
+def _merge_dict(result, overrides):
+    """ Deep-merge dictionaries
+
+    :arg dict result: The resulting dictionary
+    :arg dict overrides: Dictionay being merged into the result
+
+    :returns:
+        The resulting dictionary
+    """
+    for key in overrides:
+        if (
+            key in result and
+            isinstance(result[key], dict) and
+            isinstance(overrides[key], dict)
+        ):
+            _merge_dict(result[key], overrides[key])
+        else:
+            result[key] = overrides[key]
+    return result
+
+
 class GerritRestAPI(object):
 
     """ Interface to the Gerrit REST API.
@@ -130,11 +151,18 @@ class GerritRestAPI(object):
             requests.RequestException on timeout or connection error.
 
         """
-        kwargs.update(self.kwargs.copy())
+        args = {}
         if "data" in kwargs:
-            kwargs["headers"].update(
-                {"Content-Type": "application/json;charset=UTF-8"})
-        response = requests.put(self.make_url(endpoint), **kwargs)
+            _merge_dict(
+                args, {
+                    "headers": {
+                        "Content-Type": "application/json;charset=UTF-8"
+                    }
+                }
+            )
+        _merge_dict(args, self.kwargs.copy())
+        _merge_dict(args, kwargs)
+        response = requests.put(self.make_url(endpoint), **args)
         return _decode_response(response)
 
     def post(self, endpoint, **kwargs):
@@ -149,11 +177,18 @@ class GerritRestAPI(object):
             requests.RequestException on timeout or connection error.
 
         """
-        kwargs.update(self.kwargs.copy())
+        args = {}
         if "data" in kwargs:
-            kwargs["headers"].update(
-                {"Content-Type": "application/json;charset=UTF-8"})
-        response = requests.post(self.make_url(endpoint), **kwargs)
+            _merge_dict(
+                args, {
+                    "headers": {
+                        "Content-Type": "application/json;charset=UTF-8"
+                    }
+                }
+            )
+        _merge_dict(args, self.kwargs.copy())
+        _merge_dict(args, kwargs)
+        response = requests.post(self.make_url(endpoint), **args)
         return _decode_response(response)
 
     def delete(self, endpoint, **kwargs):
@@ -168,8 +203,18 @@ class GerritRestAPI(object):
             requests.RequestException on timeout or connection error.
 
         """
-        kwargs.update(self.kwargs.copy())
-        response = requests.delete(self.make_url(endpoint), **kwargs)
+        args = {}
+        if "data" in kwargs:
+            _merge_dict(
+                args, {
+                    "headers": {
+                        "Content-Type": "application/json;charset=UTF-8"
+                    }
+                }
+            )
+        _merge_dict(args, self.kwargs.copy())
+        _merge_dict(args, kwargs)
+        response = requests.delete(self.make_url(endpoint), **args)
         return _decode_response(response)
 
     def review(self, change_id, revision, review):

--- a/pygerrit2/rest/__init__.py
+++ b/pygerrit2/rest/__init__.py
@@ -152,7 +152,7 @@ class GerritRestAPI(object):
 
         """
         args = {}
-        if "data" in kwargs:
+        if "data" in kwargs or "json" in kwargs:
             _merge_dict(
                 args, {
                     "headers": {
@@ -178,7 +178,7 @@ class GerritRestAPI(object):
 
         """
         args = {}
-        if "data" in kwargs:
+        if "data" in kwargs or "json" in kwargs:
             _merge_dict(
                 args, {
                     "headers": {
@@ -204,7 +204,7 @@ class GerritRestAPI(object):
 
         """
         args = {}
-        if "data" in kwargs:
+        if "data" in kwargs or "json" in kwargs:
             _merge_dict(
                 args, {
                     "headers": {

--- a/unittests.py
+++ b/unittests.py
@@ -28,7 +28,7 @@
 import unittest
 
 from pygerrit2 import GerritReviewMessageFormatter
-from pygerrit2.rest import GerritReview
+from pygerrit2.rest import GerritReview, _merge_dict
 
 EXPECTED_TEST_CASE_FIELDS = ['header', 'footer', 'paragraphs', 'result']
 
@@ -106,6 +106,60 @@ TEST_CASES = [
      'footer': None,
      'paragraphs': [["* One", "  ", "* Two"]],
      'result': "* One\n* Two"}]
+
+
+class TestMergeDict(unittest.TestCase):
+
+    def test_merge_into_empty_dict(self):
+        dct = {}
+        _merge_dict(dct, {'a': 1, 'b': 2})
+        self.assertEqual(dct, {'a': 1, 'b': 2})
+
+    def test_merge_flat(self):
+        dct = {'c': 3}
+        _merge_dict(dct, {'a': 1, 'b': 2})
+        self.assertEqual(dct, {'a': 1, 'b': 2, 'c': 3})
+
+    def test_merge_with_override(self):
+        dct = {'a': 1}
+        _merge_dict(dct, {'a': 0, 'b': 2})
+        self.assertEqual(dct, {'a': 0, 'b': 2})
+
+    def test_merge_two_levels(self):
+        dct = {
+            'a': {
+                'A': 1,
+                'AA': 2,
+            },
+            'b': {
+                'B': 1,
+                'BB': 2,
+            },
+        }
+        overrides = {
+            'a': {
+                'AAA': 3,
+            },
+            'b': {
+                'BBB': 3,
+            },
+        }
+        _merge_dict(dct, overrides)
+        self.assertEqual(
+            dct,
+            {
+                'a': {
+                    'A': 1,
+                    'AA': 2,
+                    'AAA': 3,
+                },
+                'b': {
+                    'B': 1,
+                    'BB': 2,
+                    'BBB': 3,
+                },
+            }
+        )
 
 
 class TestGerritReviewMessageFormatter(unittest.TestCase):


### PR DESCRIPTION
Re-submit of https://github.com/sonyxperiadev/pygerrit/pull/35

Some of Gerrit's REST APIs expect requests with Content-Type different than 'application/json'. Configuring SSH keys is a good example (/accounts/self/sshkeys/).

This PR allows the caller of REST API to provide headers (including Content-Type) which will then override defaults specified in pygerrit2.

Example:

```python
key = {
    'algorithm': 'ssh-rsa',
    'encoded_key': '...'
    'comment': '...',
}
gerrit.post(
    '/accounts/self/sshkeys/',
    data='%(algorithm)s %(encoded_key)s %(comment)s' % key,
    headers={
        "Content-Type": "text/plain; charset=UTF-8"
    }
)
```