### PR TITLE
returning raw response for non-JSON Content-Type

### DIFF
--- a/pygerrit2/rest/__init__.py
+++ b/pygerrit2/rest/__init__.py
@@ -44,6 +44,9 @@ def _decode_response(response):
     content = response.content.strip().decode("UTF-8")
     logging.debug(content[:512])
     response.raise_for_status()
+    content_type = response.headers.get('content-type', '')
+    if content_type.split(';')[0] != 'application/json':
+        return content
     if content.startswith(GERRIT_MAGIC_JSON_PREFIX):
         content = content[len(GERRIT_MAGIC_JSON_PREFIX):]
     try:


### PR DESCRIPTION
A number of Gerrit's APIs return (or may return) response encoded as text or
HTTP 204 No Content

With this change, gerrit2 looks at response's content-type header and skips
JSON parsing for responses other than application/json