### PR TITLE
rest: handle endpoints that don't output json

### DIFF
--- a/pygerrit2/rest/__init__.py
+++ b/pygerrit2/rest/__init__.py
@@ -144,6 +144,25 @@ class GerritRestAPI(object):
         response = self.session.get(self.make_url(endpoint), **kwargs)
         return _decode_response(response)
 
+    def get_raw(self, endpoint, **kwargs):
+        """ Send HTTP GET to the endpoint. Return raw result
+
+        :arg str endpoint: The endpoint to send to.
+
+        :returns:
+            Raw result.
+
+        :raises:
+            requests.RequestException on timeout or connection error.
+
+        """
+        kwargs.update(self.kwargs.copy())
+        response = requests.get(self.make_url(endpoint), **kwargs)
+        content = response.content.strip()
+        response.raise_for_status()
+
+        return content
+
     def put(self, endpoint, **kwargs):
         """ Send HTTP PUT to the endpoint.
 


### PR DESCRIPTION
The /changes/<id>/revisions/current/patch?zip endpoint doesn't return
json output but a binary data (the zipped contents of the change). The
usual get() function raises a ValueError when faced with this. As a
workaround provide a get_raw() function to allow callers to handle the
decoding of data.