### PR TITLE
rest: use encoding from response instead of UTF-8

### DIFF
--- a/pygerrit2/rest/__init__.py
+++ b/pygerrit2/rest/__init__.py
@@ -41,7 +41,9 @@ def _decode_response(response):
         requests.HTTPError if the response contains an HTTP error status code.
 
     """
-    content = response.content.strip().decode("UTF-8")
+    content = response.content.strip()
+    if response.encoding:
+        content = content.decode(response.encoding)
     logging.debug(content[:512])
     response.raise_for_status()
     content_type = response.headers.get('content-type', '')


### PR DESCRIPTION
Some of the gerrit endpoints return things other than 'application/json'
when they do we can't assume that the encoding is UTF-8. Since the
requests library makes an educated guess about the encoding we can use
that instead.