### PR TITLE
Support returning the response object

### DIFF
--- a/pygerrit2/rest/__init__.py
+++ b/pygerrit2/rest/__init__.py
@@ -115,7 +115,6 @@ class GerritRestAPI(object):
 
         if not self.url.endswith('/'):
             self.url += '/'
-        logging.debug("url %s", self.url)
 
     def make_url(self, endpoint):
         """ Make the full url for the endpoint.

--- a/pygerrit2/rest/__init__.py
+++ b/pygerrit2/rest/__init__.py
@@ -115,6 +115,7 @@ class GerritRestAPI(object):
 
         if not self.url.endswith('/'):
             self.url += '/'
+        logging.debug("url %s", self.url)
 
     def make_url(self, endpoint):
         """ Make the full url for the endpoint.
@@ -128,10 +129,11 @@ class GerritRestAPI(object):
         endpoint = endpoint.lstrip('/')
         return self.url + endpoint
 
-    def get(self, endpoint, **kwargs):
+    def get(self, endpoint, return_response=False, **kwargs):
         """ Send HTTP GET to the endpoint.
 
         :arg str endpoint: The endpoint to send to.
+        :arg bool return_response: If true will also return the response
 
         :returns:
             JSON decoded result.
@@ -142,9 +144,14 @@ class GerritRestAPI(object):
         """
         kwargs.update(self.kwargs.copy())
         response = self.session.get(self.make_url(endpoint), **kwargs)
-        return _decode_response(response)
 
-    def put(self, endpoint, **kwargs):
+        decoded_response = _decode_response(response)
+
+        if return_response:
+            return decoded_response, response
+        return decoded_response
+
+    def put(self, endpoint, return_response=False, **kwargs):
         """ Send HTTP PUT to the endpoint.
 
         :arg str endpoint: The endpoint to send to.
@@ -168,9 +175,14 @@ class GerritRestAPI(object):
         _merge_dict(args, self.kwargs.copy())
         _merge_dict(args, kwargs)
         response = self.session.put(self.make_url(endpoint), **args)
-        return _decode_response(response)
 
-    def post(self, endpoint, **kwargs):
+        decoded_response = _decode_response(response)
+
+        if return_response:
+            return decoded_response, response
+        return decoded_response
+
+    def post(self, endpoint, return_response=False, **kwargs):
         """ Send HTTP POST to the endpoint.
 
         :arg str endpoint: The endpoint to send to.
@@ -194,9 +206,14 @@ class GerritRestAPI(object):
         _merge_dict(args, self.kwargs.copy())
         _merge_dict(args, kwargs)
         response = self.session.post(self.make_url(endpoint), **args)
-        return _decode_response(response)
 
-    def delete(self, endpoint, **kwargs):
+        decoded_response = _decode_response(response)
+
+        if return_response:
+            return decoded_response, response
+        return decoded_response
+
+    def delete(self, endpoint, return_response=False, **kwargs):
         """ Send HTTP DELETE to the endpoint.
 
         :arg str endpoint: The endpoint to send to.
@@ -220,7 +237,12 @@ class GerritRestAPI(object):
         _merge_dict(args, self.kwargs.copy())
         _merge_dict(args, kwargs)
         response = self.session.delete(self.make_url(endpoint), **args)
-        return _decode_response(response)
+
+        decoded_response = _decode_response(response)
+
+        if return_response:
+            return decoded_response, response
+        return decoded_response
 
     def review(self, change_id, revision, review):
         """ Submit a review.


### PR DESCRIPTION
This change adds support to return the response object so the caller can parse the status code for verification. For instance my usecase is I want to have tighter restrictions on the status code and sometimes ignore 404 errors.

```python
class GerritRestApi(object):
    def __init__(self, host, username, password):
        self.host = host
        self.auth = requests.auth.HTTPDigestAuth(username, password)

    def read_json_response(self, url, host=None, reqtype='GET', body=None, expect_status=200, ignore_404=True):
        """
        Sends a request to the host and returns the JSON parsed response
        """
        rest = GerritRestAPI(url=host or self.host, auth=self.auth)

        try:
            if reqtype == 'GET':
                response_body, response = rest.get(url, return_response=True, data=str(body))
            elif reqtype == 'PUT':
                response_body, response = rest.put(url, return_response=True, data=str(body))
            elif reqtype == 'POST':
                response_body, response = rest.post(url, return_response=True, data=str(body))
            elif reqtype == 'DELETE':
                response_body, response = rest.delete(url, return_response=True)
            else:
                raise RuntimeError('Unsupported Request type: %s' % reqtype)
        except requests.HTTPError as e:
            if ignore_404 and e.response.status_code == 404:
                return None
            if e.response.status_code == expect_status:
                return None
            raise GerritRestError(e.response.status_code, '%s' % str(e))

        if response.status_code != expect_status:
            raise GerritRestError(response.status_code, 'Status code (%s) does not match expected code (%s)' %
                              (response.status_code, expect_status))

        return response_body
```