### PR TITLE
Fix a bug preventing file upload in PUT and POST

### DIFF
--- a/pygerrit2/rest/__init__.py
+++ b/pygerrit2/rest/__init__.py
@@ -163,7 +163,7 @@ class GerritRestAPI(object):
 
         """
         args = {}
-        if "data" in kwargs or "json" in kwargs:
+        if ("data" in kwargs and isinstance(kwargs["data"], dict)) or "json" in kwargs:
             _merge_dict(
                 args, {
                     "headers": {
@@ -194,7 +194,7 @@ class GerritRestAPI(object):
 
         """
         args = {}
-        if "data" in kwargs or "json" in kwargs:
+        if ("data" in kwargs and isinstance(kwargs["data"], dict)) or "json" in kwargs:
             _merge_dict(
                 args, {
                     "headers": {


### PR DESCRIPTION
```Content-Type: application/json;charset=UTF-8``` was set without consideration for the actual payload passed to the function.
When sending bytes or file-like object, you should not specify the Content-Type (or else you get ```400 Bad Request``` from Gerrit)

An example of a resource that takes raw data as input can be found here: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#put-edit-file