### PR TITLE
add HTTPBasicAuth in pygerrit2 to avoid user import requests again

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ to Gerrit is done via HTTP Basic authentication, using an explicitly given
 username and password:
 
 ```python
-from requests.auth import HTTPBasicAuth
+from pygerrit2.rest.auth import HTTPBasicAuth
 from pygerrit2.rest import GerritRestAPI
 
 auth = HTTPBasicAuth('username', 'password')

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ This simple example shows how to get the user's open changes. Authentication
 to Gerrit is done via HTTP Basic authentication, using an explicitly given
 username and password::
 
-    >>> from requests.auth import HTTPBasicAuth
+    >>> from pygerrit2.rest.auth import HTTPBasicAuth
     >>> from pygerrit2.rest import GerritRestAPI
     >>> auth = HTTPBasicAuth('username', 'password')
     >>> rest = GerritRestAPI(url='http://review.example.net', auth=auth)

--- a/pygerrit2/rest/auth.py
+++ b/pygerrit2/rest/auth.py
@@ -22,8 +22,23 @@
 
 """ Authentication handlers. """
 
-from requests.auth import HTTPDigestAuth, HTTPBasicAuth
+from requests.auth import HTTPDigestAuth
 from requests.utils import get_netrc_auth
+from requests.auth import HTTPBasicAuth as BasicAuth
+
+
+class HTTPBasicAuth(BasicAuth):
+
+    """ HTTP Basic Auth.
+
+    It inherits from requests HTTPBasicAuth.
+    By using it, the user no need to import
+    requests library again.
+
+    """
+
+    def __init__(self, user, password):
+        super(HTTPBasicAuth, self).__init__(user, password)
 
 
 class HTTPDigestAuthFromNetrc(HTTPDigestAuth):


### PR DESCRIPTION
in this way, the user who use pygerrit2 no need to import requests in his own code
