### PR TITLE
Fixed an issue with duplicate output log message.

### DIFF
--- a/pygerrit2/rest/__init__.py
+++ b/pygerrit2/rest/__init__.py
@@ -28,11 +28,14 @@ import requests
 
 from .auth import HTTPBasicAuthFromNetrc
 
-logging.basicConfig(
-    level=logging.WARNING,
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    datefmt="[%y-%m-%d %H:%M:%S]")
 logger = logging.getLogger("pygerrit2")
+fmt = "%(asctime)s-[%(name)s-%(levelname)s] %(message)s"
+datefmt = "[%y-%m-%d %H:%M:%S]"
+sh = logging.StreamHandler()
+sh.setLevel(logging.WARNING)
+sh.setFormatter(logging.Formatter(fmt, datefmt))
+if not logger.handlers:
+    logger.addHandler(sh)
 
 GERRIT_MAGIC_JSON_PREFIX = ")]}\'\n"
 GERRIT_AUTH_SUFFIX = "/a"


### PR DESCRIPTION
logging.BasicConfig() creating a StreamHandler with a default Formatter
and adding it to the root logger. Developers may unknowingly make the
logger contain duplicate handlers, leading to unexpected results such as
messages being duplicated in the log.

To maintain the log format, it is better to explicitly add streamhandler
to the named logger.

Signed-off-by: z-w-k <welcome.albert.z@gmail.com>