### PR TITLE
Allow setting tag when posting review

### DIFF
--- a/livetests.py
+++ b/livetests.py
@@ -189,6 +189,7 @@ class TestGerritAgainstLiveServer(object):
         review = GerritReview()
         review.set_message("Review from live test")
         review.add_labels({"Code-Review": 1})
+        review.set_tag("a_test_tag")
         gerrit_api.review(change_id, "current", review)
 
 

--- a/pygerrit2/rest/__init__.py
+++ b/pygerrit2/rest/__init__.py
@@ -279,12 +279,14 @@ class GerritReview(object):
     :arg str message: (optional) Cover message.
     :arg dict labels: (optional) Review labels.
     :arg dict comments: (optional) Inline comments.
+    :arg str tag: (optional) Review tag.
 
     """
 
-    def __init__(self, message=None, labels=None, comments=None):
+    def __init__(self, message=None, labels=None, comments=None, tag=None):
         """See class docstring."""
         self.message = message if message else ""
+        self.tag = tag if tag else ""
         if labels:
             if not isinstance(labels, dict):
                 raise ValueError("labels must be a dict.")
@@ -306,6 +308,14 @@ class GerritReview(object):
 
         """
         self.message = message
+
+    def set_tag(self, tag):
+        """Set review tag.
+
+        :arg str tag: Review tag.
+
+        """
+        self.tag = tag
 
     def add_labels(self, labels):
         """Add labels.
@@ -362,6 +372,8 @@ class GerritReview(object):
         review_input = {}
         if self.message:
             review_input.update({"message": self.message})
+        if self.tag:
+            review_input.update({"tag": self.tag})
         if self.labels:
             review_input.update({"labels": self.labels})
         if self.comments:


### PR DESCRIPTION
By calling the set_tag method it is now possible to set a specific
tag when posting a review.