### PR TITLE
Remove earlier live-tested versions to reduce pull

### DIFF
--- a/livetests.py
+++ b/livetests.py
@@ -51,7 +51,7 @@ def _initialize(api):
 
 
 @pytest.fixture(
-    scope="module", params=["3.1.15", "3.2.10", "3.3.4", "3.4.0"]
+    scope="module", params=["3.4.0"]  # Keep list for once it expands again
 )
 def gerrit_api(request):
     """Create a Gerrit container for the given version and return an API."""


### PR DESCRIPTION
Start addressing the docker anonymous rate limiting [1] (since Q4 2020)
this way. Try to at least reduce the high CI failure rate caused by [1].
This is also to try postponing the use of either a free, OSS or payed
subscription [2] with authentication [3].

This May 2021 end also means a near, likely (mandatory) migration from
travis-ci.org to travis-ci.com. That mandatory migration [4] implies the
currently used free plan to become a trial one [5], capped to 10k
"credits". As for Docker [2], Travis offers conditional OSS support [5].

[1] https://www.docker.com/increase-rate-limits
[2] https://www.docker.com/pricing
[3] https://docs.travis-ci.com/user/docker/#pushing-a-docker-image-to-a-registry
[4] https://docs.travis-ci.com/user/migrate/open-source-repository-migration#migrating-a-repository
[5] https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing