### PR TITLE
Sort listed Pipfile {dev-}packages alphabetically

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,22 +4,22 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-typing_extensions = "*"
-requests = "*"
 e1839a8 = { path = ".", editable = true }
+requests = "*"
+typing_extensions = "*"
 
 [dev-packages]
+e1839a8 = { path = ".", editable = true }
 black = { version = "==21.5b2", markers = "python_version >= '3.6.2'" }
-pbr = "*"
-pydocstyle = "*"
 flake8 = "*"
 importlib_metadata = { version = "==4.4.0", markers = "python_version >= '3.6.0'" }
+mock = "*"
+pbr = "*"
+pydocstyle = "*"
 pyflakes = "*"
 pytest = "*"
-testcontainers = "*"
-mock = "*"
-e1839a8 = { path = ".", editable = true }
 six = "*"
+testcontainers = "*"
 
 [pipenv]
 allow_prereleases = true


### PR DESCRIPTION
While keeping the e1839a8 line at the beginning of each package section.

Do so to ease maintenance or manual /visual lookup of specific packages.